### PR TITLE
Fix sentiment badge template literal parsing

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -625,7 +625,7 @@ function getHTML() {
         const sentiment = (row.side || '').toLowerCase();
         const sentimentClassMap = { bullish: 'badge-bullish', bearish: 'badge-bearish', neutral: 'badge-neutral' };
         const sentimentClass = sentimentClassMap[sentiment] || '';
-        const sentimentClassSuffix = sentimentClass ? ` ${sentimentClass}` : '';
+        const sentimentClassSuffix = sentimentClass ? ' ' + sentimentClass : '';
         const normalizedSide = row.side ? String(row.side).toUpperCase() : '';
         const sentimentBadge = row.side
           ? `<span class="badge${sentimentClassSuffix}">${escapeHtml(normalizedSide)}</span>`

--- a/worker.js
+++ b/worker.js
@@ -628,7 +628,7 @@ function getHTML() {
         const sentimentClassSuffix = sentimentClass ? ' ' + sentimentClass : '';
         const normalizedSide = row.side ? String(row.side).toUpperCase() : '';
         const sentimentBadge = row.side
-          ? `<span class="badge${sentimentClassSuffix}">${escapeHtml(normalizedSide)}</span>`
+          ? '<span class="badge' + sentimentClassSuffix + '">' + escapeHtml(normalizedSide) + '</span>'
           : '';
         const sweepBadge = row.sweep ? '<span class="badge badge-sweep">Sweep</span>' : '';
         return `<tr>

--- a/worker.js
+++ b/worker.js
@@ -625,8 +625,10 @@ function getHTML() {
         const sentiment = (row.side || '').toLowerCase();
         const sentimentClassMap = { bullish: 'badge-bullish', bearish: 'badge-bearish', neutral: 'badge-neutral' };
         const sentimentClass = sentimentClassMap[sentiment] || '';
+        const sentimentClassSuffix = sentimentClass ? ` ${sentimentClass}` : '';
+        const normalizedSide = row.side ? String(row.side).toUpperCase() : '';
         const sentimentBadge = row.side
-          ? '<span class="badge' + (sentimentClass ? ' ' + sentimentClass : '') + '">' + escapeHtml(String(row.side).toUpperCase()) + '</span>'
+          ? `<span class="badge${sentimentClassSuffix}">${escapeHtml(normalizedSide)}</span>`
           : '';
         const sweepBadge = row.sweep ? '<span class="badge badge-sweep">Sweep</span>' : '';
         return `<tr>

--- a/worker.js
+++ b/worker.js
@@ -631,23 +631,23 @@ function getHTML() {
           ? '<span class="badge' + sentimentClassSuffix + '">' + escapeHtml(normalizedSide) + '</span>'
           : '';
         const sweepBadge = row.sweep ? '<span class="badge badge-sweep">Sweep</span>' : '';
-        return `<tr>
-            <td><span class="cell-inline"><span class="ticker">${escapeHtml(row.ticker || '-')}</span>${sweepBadge}</span></td>
-            <td>${sentimentBadge}</td>
-            <td>${escapeHtml(row.type || '-')}</td>
-            <td>${formatCurrency(row.premium)}</td>
-            <td>${formatNumber(row.strike)}</td>
-            <td>${escapeHtml(row.expiry || '-')}</td>
-            <td>${formatCurrency(row.trade_price)}</td>
-            <td>${formatNumber(row.quantity)}</td>
-            <td>${escapeHtml(row.time || '-')}</td>
-            <td>${formatCurrency(row.underlying_price)}</td>
-          </tr>`;
+        return '<tr>' +
+            '<td><span class="cell-inline"><span class="ticker">' + escapeHtml(row.ticker || '-') + '</span>' + sweepBadge + '</span></td>' +
+            '<td>' + sentimentBadge + '</td>' +
+            '<td>' + escapeHtml(row.type || '-') + '</td>' +
+            '<td>' + formatCurrency(row.premium) + '</td>' +
+            '<td>' + formatNumber(row.strike) + '</td>' +
+            '<td>' + escapeHtml(row.expiry || '-') + '</td>' +
+            '<td>' + formatCurrency(row.trade_price) + '</td>' +
+            '<td>' + formatNumber(row.quantity) + '</td>' +
+            '<td>' + escapeHtml(row.time || '-') + '</td>' +
+            '<td>' + formatCurrency(row.underlying_price) + '</td>' +
+          '</tr>';
       }).join('');
 
       pager.hidden = false;
-      const totalLabel = typeof payload?.count === 'number' ? ` of ${payload.count}` : '';
-      pagerInfo.textContent = `Page ${currentPage} • Showing ${rows.length}${totalLabel} results`;
+      const totalLabel = typeof payload?.count === 'number' ? ' of ' + payload.count : '';
+      pagerInfo.textContent = 'Page ' + currentPage + ' • Showing ' + rows.length + totalLabel + ' results';
       prevPageBtn.disabled = currentPage <= 1;
       nextPageBtn.disabled = rows.length < pageSize;
 


### PR DESCRIPTION
## Summary
- adjust the sentiment badge markup to build safely with template literals
- normalize the option side label before escaping for output

## Testing
- node --check worker.js

------
https://chatgpt.com/codex/tasks/task_b_68dc015078b483289d18b2abad3505f0