### PR TITLE
Use cost basis as premium fallback

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -167,6 +167,7 @@ function normalizeBenzingaPayload(data) {
     const premium = Number(
       row?.total_trade_value ??
         row?.total_cost ??
+        row?.cost_basis ??
         row?.premium ??
         row?.notional_value ??
         row?.notional ??


### PR DESCRIPTION
## Summary
- update premium normalization to consider cost_basis from the Benzinga payload

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e4415210e883288444cb297f7982b7