### PR TITLE
Restore vertical scrolling

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -298,7 +298,8 @@ function getHTML() {
       justify-content: center;
       padding: 32px 20px 48px;
       position: relative;
-      overflow: hidden;
+      overflow-x: hidden;
+      overflow-y: auto;
     }
 
     body::before,


### PR DESCRIPTION
## Summary
- allow the page to scroll vertically by restoring overflow-y on the body element

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e50381827883288185191dc04be371